### PR TITLE
 1. Auto-release GitHub Actions workflow (.github/workflows/auto-rele…

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,0 +1,138 @@
+---
+name: Auto Release
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+jobs:
+  auto-release:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Need full history for version calculation
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure git
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email \
+            "github-actions[bot]@users.noreply.github.com"
+
+      - name: Determine next version
+        id: version
+        run: |
+          # Get the current version from the last tag
+          CURRENT_VERSION=$(git describe --tags --abbrev=0 2>/dev/null || \
+            echo "v0.0.0")
+          echo "Current version: $CURRENT_VERSION"
+
+          # Remove 'v' prefix for processing
+          CURRENT_VERSION_NUM=${CURRENT_VERSION#v}
+
+          # Extract PR labels to determine version bump type
+          PR_LABELS='${{ toJson(github.event.pull_request.labels.*.name) }}'
+          echo "PR Labels: $PR_LABELS"
+
+          # Parse current version
+          IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT_VERSION_NUM"
+          MAJOR=${MAJOR:-0}
+          MINOR=${MINOR:-0}
+          PATCH=${PATCH:-0}
+
+          # Determine version bump based on PR labels
+          if echo "$PR_LABELS" | grep -q "breaking"; then
+            # Major version bump for breaking changes
+            MAJOR=$((MAJOR + 1))
+            MINOR=0
+            PATCH=0
+          elif echo "$PR_LABELS" | grep -q "feature\|enhancement"; then
+            # Minor version bump for new features
+            MINOR=$((MINOR + 1))
+            PATCH=0
+          else
+            # Patch version bump for bug fixes and other changes
+            PATCH=$((PATCH + 1))
+          fi
+
+          NEW_VERSION="$MAJOR.$MINOR.$PATCH"
+          echo "New version: $NEW_VERSION"
+          echo "version=$NEW_VERSION" >> $GITHUB_OUTPUT
+
+      - name: Create release
+        run: |
+          # Make the release script executable
+          chmod +x scripts/create_release.sh
+
+          # Check git status
+          git status --porcelain
+
+          # Create the release using our script
+          ./scripts/create_release.sh --push \
+            ${{ steps.version.outputs.version }}
+
+      - name: Create GitHub Release
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          TAG_NAME="v${VERSION}"
+
+          # Create release notes
+          cat > release_notes.md << 'EOF'
+          ## Changes in this release
+
+          This release was automatically created from PR \
+          #${{ github.event.pull_request.number }}: \
+          ${{ github.event.pull_request.title }}
+
+          **PR Description:**
+          ${{ github.event.pull_request.body }}
+
+          **Merged by:** @${{ github.event.pull_request.user.login }}
+          **Merge commit:** ${{ github.event.pull_request.merge_commit_sha }}
+
+          ### Pre-commit Configuration Updates
+
+          This release includes updates to the pre-commit hook configuration:
+          - Updated hook versions and configurations
+          - New or modified linting rules
+          - Security and code quality improvements
+
+          ### Release Assets
+
+          - Source code archives are available below
+          - Pre-commit configuration ready to use
+          - Release created automatically by GitHub Actions
+
+          ---
+
+          🤖 Generated with GitHub Actions
+          EOF
+
+          # Create the release using GitHub CLI with assets if they exist
+          RELEASE_ARGS=(
+            "$TAG_NAME"
+            --title "Release $TAG_NAME"
+            --notes-file release_notes.md
+            --latest
+          )
+
+          # Add release assets if they exist
+          if [ -f "releases/pre-commit-config-v${VERSION}.tar.gz" ]; then
+            RELEASE_ARGS+=("releases/pre-commit-config-v${VERSION}.tar.gz")
+          fi
+
+          if [ -f "releases/pre-commit-config-v${VERSION}.zip" ]; then
+            RELEASE_ARGS+=("releases/pre-commit-config-v${VERSION}.zip")
+          fi
+
+          gh release create "${RELEASE_ARGS[@]}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/create_release.sh
+++ b/scripts/create_release.sh
@@ -330,21 +330,28 @@ create_source_archives() {
 push_to_remote() {
     local version="$1"
     local tag="v$version"
+    local push_opts=()
+    local force_msg=""
+
+    if [[ "$FORCE" == "true" ]]; then
+        push_opts+=("--force")
+        force_msg=" (with --force)"
+    fi
 
     if [[ "$PUSH" != "true" ]]; then
         log_info "To push this release to remote repository:"
-        log_info "  git push ${GIT_REMOTE:-origin} $tag"
+        log_info "  git push ${push_opts[*]} ${GIT_REMOTE:-origin} $tag"
         return 0
     fi
 
     if [[ "$DRY_RUN" == "true" ]]; then
-        log_info "DRY RUN: Would push tag to remote: $tag"
+        log_info "DRY RUN: Would push tag to remote: git push ${push_opts[*]} ${GIT_REMOTE:-origin} $tag"
         return 0
     fi
 
-    log_info "Pushing tag to remote repository..."
+    log_info "Pushing tag to remote repository${force_msg}..."
 
-    if git push "${GIT_REMOTE:-origin}" "$tag"; then
+    if git push "${push_opts[@]}" "${GIT_REMOTE:-origin}" "$tag"; then
         log_success "✓ Pushed tag to remote: $tag"
     else
         log_error "Failed to push tag to remote"

--- a/scripts/create_release.sh
+++ b/scripts/create_release.sh
@@ -318,7 +318,7 @@ push_to_remote() {
 
     if [[ "$PUSH" != "true" ]]; then
         log_info "To push this release to remote repository:"
-        log_info "  git push ${push_opts[@]} ${GIT_REMOTE:-origin} $tag"
+        log_info "  git push ${push_opts[*]} ${GIT_REMOTE:-origin} $tag"
         return 0
     fi
 

--- a/scripts/create_release.sh
+++ b/scripts/create_release.sh
@@ -225,13 +225,11 @@ create_git_tag() {
         changelog="Initial release."
     fi
 
-    tag_message="Release $tag
-
-Changelog:
-$changelog
-
-Release Date: $(date -u +"%Y-%m-%d %H:%M:%S UTC")
-Git Commit: $(git rev-parse HEAD)"
+    printf -v tag_message "Release %s\n\nChangelog:\n%s\n\nRelease Date: %s\nGit Commit: %s" \
+        "$tag" \
+        "$changelog" \
+        "$(date -u +'%Y-%m-%d %H:%M:%S UTC')" \
+        "$(git rev-parse HEAD)"
 
     if [[ "$FORCE" == "true" ]] && git rev-parse "$tag" >/dev/null 2>&1; then
         log_warning "Deleting existing tag: $tag"

--- a/scripts/create_release.sh
+++ b/scripts/create_release.sh
@@ -20,19 +20,19 @@ NC='\033[0m' # No Color
 
 # Helper functions
 log_info() {
-    echo -e "${CYAN}$1${NC}"
+    printf '%b\n' "${CYAN}$1${NC}"
 }
 
 log_success() {
-    echo -e "${GREEN}$1${NC}"
+    printf '%b\n' "${GREEN}$1${NC}"
 }
 
 log_warning() {
-    echo -e "${YELLOW}$1${NC}" >&2
+    printf '%b\n' "${YELLOW}$1${NC}" >&2
 }
 
 log_error() {
-    echo -e "${RED}$1${NC}" >&2
+    printf '%b\n' "${RED}$1${NC}" >&2
 }
 
 # Show usage

--- a/scripts/create_release.sh
+++ b/scripts/create_release.sh
@@ -484,6 +484,8 @@ main() {
     show_release_summary "$VERSION" "$tar_file" "$zip_file"
 }
 
-# Parse arguments and run
-parse_arguments "$@"
-main
+# Run script if executed directly
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+    parse_arguments "$@"
+    main
+fi

--- a/scripts/create_release.sh
+++ b/scripts/create_release.sh
@@ -20,19 +20,19 @@ NC='\033[0m' # No Color
 
 # Helper functions
 log_info() {
-    printf '%b\n' "${CYAN}$1${NC}"
+    printf "${CYAN}%s${NC}\n" "$1"
 }
 
 log_success() {
-    printf '%b\n' "${GREEN}$1${NC}"
+    printf "${GREEN}%s${NC}\n" "$1"
 }
 
 log_warning() {
-    printf '%b\n' "${YELLOW}$1${NC}" >&2
+    printf "${YELLOW}%s${NC}\n" "$1" >&2
 }
 
 log_error() {
-    printf '%b\n' "${RED}$1${NC}" >&2
+    printf "${RED}%s${NC}\n" "$1" >&2
 }
 
 # Show usage

--- a/scripts/create_release.sh
+++ b/scripts/create_release.sh
@@ -318,7 +318,7 @@ push_to_remote() {
 
     if [[ "$PUSH" != "true" ]]; then
         log_info "To push this release to remote repository:"
-        log_info "  git push ${push_opts[*]} ${GIT_REMOTE:-origin} $tag"
+        log_info "  git push ${push_opts[@]} ${GIT_REMOTE:-origin} $tag"
         return 0
     fi
 

--- a/scripts/create_release.sh
+++ b/scripts/create_release.sh
@@ -1,0 +1,495 @@
+#!/bin/bash
+# Release Management Script for Pre-commit Configuration Repository
+# Creates semantic versioned releases with Git tags and source archives
+
+set -e -u -o pipefail
+
+# Configuration
+PROJECT_NAME="pre-commit-config"
+PROJECT_DISPLAY_NAME="Pre-commit Configuration"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+RELEASES_DIR="$PROJECT_ROOT/releases"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+NC='\033[0m' # No Color
+
+# Helper functions
+log_info() {
+    echo -e "${CYAN}$1${NC}"
+}
+
+log_success() {
+    echo -e "${GREEN}$1${NC}"
+}
+
+log_warning() {
+    echo -e "${YELLOW}$1${NC}" >&2
+}
+
+log_error() {
+    echo -e "${RED}$1${NC}" >&2
+}
+
+# Show usage
+show_usage() {
+    cat << EOF
+Release Management Script for ${PROJECT_DISPLAY_NAME}
+
+Usage: $0 [OPTIONS] VERSION
+
+Create a semantic versioned release with Git tags and source archives.
+
+VERSION:
+  Semantic version in format X.Y.Z (e.g., 1.2.3)
+  - X: Major version (breaking changes)
+  - Y: Minor version (new features, backward compatible)
+  - Z: Patch version (bug fixes, backward compatible)
+
+Options:
+  --dry-run           Show what would be done without making changes
+  --force             Force creation even if tag exists
+  --no-archive        Skip creating source archives
+  --push              Push tags to remote repository
+  -h, --help          Show this help
+
+Examples:
+  $0 1.2.3                    # Create release v1.2.3
+  $0 --dry-run 1.2.3          # Preview release creation
+  $0 --push 1.2.3             # Create and push to remote
+  $0 --force 1.2.3            # Force create even if tag exists
+
+Prerequisites:
+  - Clean working directory (no uncommitted changes)
+  - Git repository with at least one commit
+  - Valid semantic version number
+
+Environment Variables:
+  GIT_REMOTE              Git remote name (default: origin)
+
+EOF
+}
+
+# Validate semantic version format
+validate_version() {
+    local version="$1"
+
+    if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+        log_error "Invalid version format: $version"
+        log_error "Expected format: X.Y.Z (e.g., 1.2.3)"
+        return 1
+    fi
+
+    return 0
+}
+
+# Check if we're in a git repository
+check_git_repo() {
+    if ! git rev-parse --git-dir > /dev/null 2>&1; then
+        log_error "Not in a Git repository"
+        return 1
+    fi
+    return 0
+}
+
+# Check if working directory is clean
+check_clean_working_dir() {
+    if [[ "$DRY_RUN" == "true" ]]; then
+        log_info "DRY RUN: Skipping working directory check"
+        return 0
+    fi
+
+    if ! git diff-index --quiet HEAD --; then
+        log_error "Working directory is not clean"
+        log_error "Please commit or stash your changes before creating a release"
+        log_info "Uncommitted changes:"
+        git status --porcelain | sed 's/^/  /'
+        return 1
+    fi
+
+    return 0
+}
+
+# Check if tag already exists
+check_tag_exists() {
+    local tag="$1"
+
+    if git rev-parse "$tag" >/dev/null 2>&1; then
+        if [[ "$FORCE" == "true" ]]; then
+            log_warning "Tag $tag already exists but --force specified"
+            return 0
+        else
+            log_error "Tag $tag already exists"
+            log_error "Use --force to overwrite or choose a different version"
+            return 1
+        fi
+    fi
+
+    return 0
+}
+
+# Get current version from Git
+get_current_version() {
+    local current_tag
+    current_tag=$(git describe --tags --abbrev=0 2>/dev/null || echo "none")
+
+    if [[ "$current_tag" == "none" ]]; then
+        echo "No previous releases"
+    else
+        echo "$current_tag"
+    fi
+}
+
+# Compare versions to ensure we're moving forward
+validate_version_progression() {
+    local new_version="$1"
+    local current_tag
+
+    current_tag=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+
+    if [[ -z "$current_tag" ]]; then
+        log_info "This will be the first release"
+        return 0
+    fi
+
+    # Remove 'v' prefix if present for comparison
+    local current_version="${current_tag#v}"
+
+    # Check if versions are the same
+    if [[ "$new_version" == "$current_version" ]]; then
+        if [[ "$FORCE" != "true" ]]; then
+            log_error "Version $new_version is the same as current version $current_tag"
+            return 1
+        else
+            log_warning "Version $new_version is the same as current version $current_tag. Proceeding due to --force."
+        fi
+    else
+        # Perform semantic version comparison to prevent downgrades
+        if ! compare_semantic_versions "$new_version" "$current_version"; then
+            if [[ "$FORCE" != "true" ]]; then
+                log_error "New version v$new_version is not greater than current version $current_tag."
+                log_error "Use --force to proceed if this is intentional."
+                return 1
+            else
+                log_warning "New version v$new_version is not greater than current version $current_tag. Proceeding due to --force."
+            fi
+        fi
+    fi
+
+    log_info "Upgrading from $current_tag to v$new_version"
+    return 0
+}
+
+# Compare two semantic versions
+# Returns 0 if version1 > version2, 1 otherwise
+compare_semantic_versions() {
+    local version1="$1"
+    local version2="$2"
+
+    # Split versions into components
+    IFS='.' read -r v1_major v1_minor v1_patch <<< "$version1"
+    IFS='.' read -r v2_major v2_minor v2_patch <<< "$version2"
+
+    # Default to 0 if components are missing
+    v1_major=${v1_major:-0}; v1_minor=${v1_minor:-0}; v1_patch=${v1_patch:-0}
+    v2_major=${v2_major:-0}; v2_minor=${v2_minor:-0}; v2_patch=${v2_patch:-0}
+
+    # Compare major version
+    if ((v1_major > v2_major)); then
+        return 0
+    elif ((v1_major < v2_major)); then
+        return 1
+    fi
+
+    # Major versions are equal, compare minor version
+    if ((v1_minor > v2_minor)); then
+        return 0
+    elif ((v1_minor < v2_minor)); then
+        return 1
+    fi
+
+    # Major and minor versions are equal, compare patch version
+    if ((v1_patch > v2_patch)); then
+        return 0
+    else
+        return 1
+    fi
+}
+
+# Create the Git tag
+create_git_tag() {
+    local version="$1"
+    local tag="v$version"
+
+    if [[ "$DRY_RUN" == "true" ]]; then
+        log_info "DRY RUN: Would create tag: $tag"
+        return 0
+    fi
+
+    log_info "Creating Git tag: $tag"
+
+    # Create annotated tag with release information
+    local tag_message
+    local changelog
+    local previous_tag
+
+    previous_tag=$(git describe --tags --abbrev=0 2>/dev/null)
+
+    if [[ -n "$previous_tag" ]]; then
+        changelog=$(git log --pretty=format:'- %s' "$previous_tag"..HEAD)
+    else
+        changelog="Initial release."
+    fi
+
+    tag_message="Release $tag
+
+Changelog:
+$changelog
+
+Release Date: $(date -u +"%Y-%m-%d %H:%M:%S UTC")
+Git Commit: $(git rev-parse HEAD)"
+
+    if [[ "$FORCE" == "true" ]] && git rev-parse "$tag" >/dev/null 2>&1; then
+        log_warning "Deleting existing tag: $tag"
+        git tag -d "$tag"
+    fi
+
+    if git tag -a "$tag" -m "$tag_message"; then
+        log_success "✓ Created tag: $tag"
+    else
+        log_error "Failed to create tag: $tag"
+        return 1
+    fi
+
+    return 0
+}
+
+# Create source archives
+create_source_archives() {
+    local version="$1"
+    local archive_prefix="$2"
+    local tar_file="$3"
+    local zip_file="$4"
+    local tag="v$version"
+
+    if [[ "$NO_ARCHIVE" == "true" ]]; then
+        log_info "Skipping archive creation (--no-archive specified)"
+        return 0
+    fi
+
+    if [[ "$DRY_RUN" == "true" ]]; then
+        log_info "DRY RUN: Would create archives in $RELEASES_DIR/"
+        log_info "  - $(basename "$tar_file")"
+        log_info "  - $(basename "$zip_file")"
+        return 0
+    fi
+
+    log_info "Creating source archives..."
+
+    # Create releases directory
+    mkdir -p "$RELEASES_DIR"
+
+    # Create tar.gz archive
+    log_info "Creating $tar_file"
+    if git archive --format=tar.gz --prefix="${archive_prefix}/" "$tag" > "$tar_file"; then
+        log_success "✓ Created: $tar_file"
+    else
+        log_error "Failed to create tar.gz archive"
+        return 1
+    fi
+
+    # Create zip archive
+    log_info "Creating $zip_file"
+    if git archive --format=zip --prefix="${archive_prefix}/" "$tag" > "$zip_file"; then
+        log_success "✓ Created: $zip_file"
+    else
+        log_error "Failed to create zip archive"
+        return 1
+    fi
+
+    # Show archive sizes
+    log_info "Archive sizes:"
+    for file in "$tar_file" "$zip_file"; do
+        if [[ -f "$file" ]]; then
+            local size
+            local basename_file
+            size=$(du -h "$file" | cut -f1)
+            basename_file=$(basename "$file")
+            echo "  $size $basename_file"
+        fi
+    done
+
+    return 0
+}
+
+# Push tags to remote
+push_to_remote() {
+    local version="$1"
+    local tag="v$version"
+
+    if [[ "$PUSH" != "true" ]]; then
+        log_info "To push this release to remote repository:"
+        log_info "  git push ${GIT_REMOTE:-origin} $tag"
+        return 0
+    fi
+
+    if [[ "$DRY_RUN" == "true" ]]; then
+        log_info "DRY RUN: Would push tag to remote: $tag"
+        return 0
+    fi
+
+    log_info "Pushing tag to remote repository..."
+
+    if git push "${GIT_REMOTE:-origin}" "$tag"; then
+        log_success "✓ Pushed tag to remote: $tag"
+    else
+        log_error "Failed to push tag to remote"
+        log_warning "Tag was created locally but not pushed"
+        return 1
+    fi
+
+    return 0
+}
+
+# Show release summary
+show_release_summary() {
+    local version="$1"
+    local tar_file="$2"
+    local zip_file="$3"
+    local tag="v$version"
+
+    echo
+    log_success "=== Release Summary ==="
+    echo
+    log_info "Version: $version"
+    log_info "Git Tag: $tag"
+    log_info "Commit: $(git rev-parse HEAD)"
+
+    if [[ "$NO_ARCHIVE" != "true" && "$DRY_RUN" != "true" ]]; then
+        echo
+        log_info "Release Archives:"
+        if [[ -f "$tar_file" ]]; then
+            echo "  ✓ $tar_file"
+        fi
+        if [[ -f "$zip_file" ]]; then
+            echo "  ✓ $zip_file"
+        fi
+    fi
+
+    echo
+    if [[ "$DRY_RUN" == "true" ]]; then
+        log_warning "This was a dry run - no changes were made"
+        echo
+        log_info "To create the release for real:"
+        log_info "  $0 $version"
+    else
+        log_success "Release v$version created successfully!"
+        echo
+        if [[ "$PUSH" != "true" ]]; then
+            log_info "Next steps:"
+            log_info "  1. Push the tag: git push ${GIT_REMOTE:-origin} $tag"
+            log_info "  2. Create GitHub release (optional)"
+            log_info "  3. Update documentation (if needed)"
+        fi
+    fi
+}
+
+# Parse command line arguments
+parse_arguments() {
+    DRY_RUN="false"
+    FORCE="false"
+    NO_ARCHIVE="false"
+    PUSH="false"
+    VERSION=""
+
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+            -h|--help)
+                show_usage
+                exit 0
+                ;;
+            --dry-run)
+                DRY_RUN="true"
+                shift
+                ;;
+            --force)
+                FORCE="true"
+                shift
+                ;;
+            --no-archive)
+                NO_ARCHIVE="true"
+                shift
+                ;;
+            --push)
+                PUSH="true"
+                shift
+                ;;
+            -*)
+                log_error "Unknown option: $1"
+                show_usage
+                exit 1
+                ;;
+            *)
+                if [[ -z "$VERSION" ]]; then
+                    VERSION="$1"
+                else
+                    log_error "Multiple versions specified: $VERSION and $1"
+                    exit 1
+                fi
+                shift
+                ;;
+        esac
+    done
+
+    if [[ -z "$VERSION" ]]; then
+        log_error "Version is required"
+        show_usage
+        exit 1
+    fi
+}
+
+# Main execution
+main() {
+    log_info "=== ${PROJECT_DISPLAY_NAME} Release Creator ==="
+    echo
+
+    # Validate inputs
+    validate_version "$VERSION" || exit 1
+    check_git_repo || exit 1
+    check_clean_working_dir || exit 1
+    check_tag_exists "v$VERSION" || exit 1
+    validate_version_progression "$VERSION" || exit 1
+
+    # Show current state
+    local current_version
+    current_version=$(get_current_version)
+    log_info "Current version: $current_version"
+    log_info "New version: v$VERSION"
+
+    if [[ "$DRY_RUN" == "true" ]]; then
+        log_warning "DRY RUN MODE - No changes will be made"
+    fi
+
+    echo
+
+    # Define archive paths once
+    local archive_prefix="${PROJECT_NAME}-v$VERSION"
+    local tar_file="$RELEASES_DIR/${archive_prefix}.tar.gz"
+    local zip_file="$RELEASES_DIR/${archive_prefix}.zip"
+
+    # Create the release
+    create_git_tag "$VERSION" || exit 1
+    create_source_archives "$VERSION" "$archive_prefix" "$tar_file" "$zip_file" || exit 1
+    push_to_remote "$VERSION" || exit 1
+
+    # Show summary
+    show_release_summary "$VERSION" "$tar_file" "$zip_file"
+}
+
+# Parse arguments and run
+parse_arguments "$@"
+main


### PR DESCRIPTION
…ase.yml):

    - Triggers on merged pull requests to main branch
    - Automatically determines version bumps based on PR labels (breaking/feature/enhancement)
    - Creates Git tags and GitHub releases
    - Adapted for pre-commit configuration repository (no Python setup needed)
  2. Release script (scripts/create_release.sh):
    - Shell-based release management tool
    - Creates semantic versioned Git tags
    - Generates source archives
    - Supports dry-run, force, and push options