### PR TITLE
feat: Add TruffleHog secrets scanner to pre-commit hooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.claude
+.serena

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -62,6 +62,16 @@ repos:
       - id: sort-simple-yaml                     # sorts simple yaml files which consist only of top-level keys
       - id: trailing-whitespace                  # trims trailing whitespace.
 
+  # Comprehensive Secrets Detection with TruffleHog
+  # TruffleHog provides advanced secrets detection with verification capabilities
+  # across all supported languages (Python, Java, C/C++, Shell, Terraform, etc.)
+  - repo: https://github.com/trufflesecurity/trufflehog
+    rev: v3.90.8
+    hooks:
+      - id: trufflehog
+        name: TruffleHog Secrets Scanner
+        description: Scan for secrets using TruffleHog's advanced detection and verification
+
   # Python Security Linting
   # Finds common security issues in Python code.
   - repo: https://github.com/PyCQA/bandit.git

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -71,6 +71,8 @@ repos:
       - id: trufflehog
         name: TruffleHog Secrets Scanner
         description: Scan for secrets using TruffleHog's advanced detection and verification
+        require_serial: true
+        types: [text]
 
   # Python Security Linting
   # Finds common security issues in Python code.

--- a/scripts/install_osx.sh
+++ b/scripts/install_osx.sh
@@ -15,23 +15,23 @@ fi
 
 # Packages to install
 PACKAGES=(
-    "trufflehog"
-    "checkmake"
-    "pylint"
-    "ansible-lint"
     "ansible"
-    "pre-commit"
+    "ansible-lint"
     "black"
-    "terraform-docs"
-    "tflint"
+    "checkmake"
     "coreutils"
     "gawk"
-    "tfsec"
     "hadolint"
     "jq"
+    "markdownlint-cli"
+    "pre-commit"
+    "pylint"
+    "terraform-docs"
     "terrascan"
+    "tflint"
+    "tfsec"
     "trivy"
-    "markdownlint-cli"  # Added for markdown linting
+    "trufflehog"
 )
 
 # Function for error handling

--- a/scripts/install_osx.sh
+++ b/scripts/install_osx.sh
@@ -15,6 +15,7 @@ fi
 
 # Packages to install
 PACKAGES=(
+    "trufflehog"
     "checkmake"
     "pylint"
     "ansible-lint"

--- a/scripts/setup_run_pre-commit_linux.sh
+++ b/scripts/setup_run_pre-commit_linux.sh
@@ -91,6 +91,14 @@ if [ -x "$(command -v apt)" ]; then
     curl -fsSL https://raw.githubusercontent.com/infracost/infracost/master/scripts/install.sh | sh || \
       install_error "infracost"
 
+    echo "Installing TruffleHog..."
+    if ! command -v trufflehog &> /dev/null; then
+        curl -sSfL https://raw.githubusercontent.com/trufflesecurity/trufflehog/main/scripts/install.sh | sh -s -- -b /usr/local/bin || \
+          install_error "trufflehog"
+    else
+        echo "TruffleHog already installed"
+    fi
+
 elif [ -x "$(command -v yum)" ]; then
     echo "RPM-based system detected"
 


### PR DESCRIPTION
## Summary

- Added TruffleHog v3.90.8 secrets scanner to detect credentials, API keys, and sensitive data
- Configured scanner to work across all supported languages (Python, Java, C/C++, Shell, Terraform, etc.)
- Added `.gitignore` to exclude `.claude` and `.serena` tool directories
- Added `trufflehog` to macOS install script

## Test plan

- [x] All pre-commit hooks pass successfully
- [x] TruffleHog scanner executes without errors
- [x] Configuration validated with `pre-commit run --all-files`

🤖 Generated with [Claude Code](https://claude.com/claude-code)